### PR TITLE
Update jsdom version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.6",
-    "jsdom": "0.8.8"
+    "jsdom": "~4.0.2"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
This updates the jsdom version to 4.0.2.  

I ran into this error:

```
[Thu Mar 05 2015 22:23:59 GMT-0500 (EST)] ERROR RangeError: The normalization form should be one of NFC, NFD, NFKC, NFKD.
  at String.normalize (native)
  at Object.src (/home/hubot/buckiibot/node_modules/hubot-devops-reactions/node_modules/jsdom/lib/jsdom/level2/html.js:220:21)
  at /home/hubot/buckiibot/node_modules/hubot-devops-reactions/node_modules/jsdom/lib/jsdom.js:274:18
  at Array.forEach (native)
  at processHTML (/home/hubot/buckiibot/node_modules/hubot-devops-reactions/node_modules/jsdom/lib/jsdom.js:269:20)
  at Request._callback (/home/hubot/buckiibot/node_modules/hubot-devops-reactions/node_modules/jsdom/lib/jsdom.js:205:7)
  at Request.self.callback (/home/hubot/buckiibot/node_modules/hubot-devops-reactions/node_modules/jsdom/node_modules/request/request.js:344:22)
  at Request.emit (events.js:110:17)
  at Request.<anonymous> (/home/hubot/buckiibot/node_modules/hubot-devops-reactions/node_modules/jsdom/node_modules/request/request.js:1239:14)
  at Request.emit (events.js:129:20)
  at IncomingMessage.<anonymous> (/home/hubot/buckiibot/node_modules/hubot-devops-reactions/node_modules/jsdom/node_modules/request/request.js:1187:12)
  at IncomingMessage.emit (events.js:129:20)
  at _stream_readable.js:908:16
  at process._tickCallback (node.js:355:11)
```

Which was fixed in jsdom by tmpvar/jsdom#769.  
